### PR TITLE
Update to reflect the latest built-in mpv config - Windows branch

### DIFF
--- a/mpv.conf
+++ b/mpv.conf
@@ -1,16 +1,12 @@
 # ==========    GENERAL    ==========
 
-# This is what profile=gpu-hq do:
-# scale=spline36
-# cscale=spline36
-# dscale=mitchell
-# dither-depth=auto
-# correct-downscaling=yes
-# linear-downscaling=yes
-# sigmoid-upscaling=yes
+# This is what profile=high-quality do:
+# scale=ewa_lanczossharp (This also changes the cscale)
+# hdr-peak-percentile=99.995
+# hdr-contrast-recovery=0.30
 # deband=yes
 
-profile=gpu-hq                                  # Allows for higher quality playback on mpv
+profile=high-quality                            # Allows for higher quality playback on mpv
                                                 # Uses scaling methods that are significantly better than default mpv, VLC and MPC
 vo=gpu                                          # https://mpv.io/manual/stable/#video-output-drivers-gpu
 priority=high                                   # Makes PC prioritize MPV for allocating resources (Windows only)
@@ -31,10 +27,9 @@ hwdec=nvdec                                     # Recommended method to do hardw
 
 # ==========    SCALERS AND SHADERS    ==========
 
-# Default was (because of profile=gpu-hq):
-# scale=spline36
-# cscale=spline36
-# dscale=mitchell
+# Default was:
+# dscale=hermite (because of mpv 0.37.0)
+# cscale=ewa_lanczossharp (because of profile=high-quality)
 
 scale=ewa_lanczossharp                          # Luma upscaler
 dscale=mitchell                                 # Luma downscaler


### PR DESCRIPTION
gpu-hq is deprecated and now an alias of high-quality. Check https://github.com/mpv-player/mpv/blob/master/etc/builtin.conf for more info
the default of dscale is hermite since mpv 0.37.0